### PR TITLE
Reduce container image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,35 @@
-FROM golang:latest
+FROM golang:1.23 AS builder
 
-# ###################################
-# install pixlet
-ENV NODE_URL=https://deb.nodesource.com/setup_21.x
 ENV PIXLET_REPO=https://github.com/tavdog/pixlet
 
-RUN apt update && apt upgrade -y && apt install cron libwebp-dev python3-pip python3-flask python3-gunicorn -y
-RUN pip3 install --break-system-packages python-dotenv paho-mqtt python-pidfile esptool
-WORKDIR /tmp
-RUN curl -fsSL $NODE_URL | bash - && apt-get install -y nodejs && node -v
-
+# build pixlet
+RUN apt-get update && apt-get install --no-install-recommends npm libwebp-dev -y \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 WORKDIR /
 RUN git clone --depth 1 $PIXLET_REPO /pixlet
 WORKDIR /pixlet
 RUN npm install && npm run build && make build
 
+FROM python:3.13-slim AS runtime
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update && apt-get install --no-install-recommends -y cron libwebp7 git \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+WORKDIR /tmp
+
+# Copy the built pixlet binary from the builder stage
+COPY --from=builder /pixlet/pixlet /pixlet/pixlet
+
+# Set up the environment for the Flask app
 WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir -r requirements.txt
+
 # 8000 for main app, 5100,5102 for pixlet serve iframe 
 EXPOSE 8000 5100 5101
 
-# docker-compose will start the container
-## start the app
-## CMD ["./run"]
+# start the app
+CMD ["./run"]

--- a/clone_system_apps_repo.py
+++ b/clone_system_apps_repo.py
@@ -4,7 +4,23 @@ import json,os,sys,subprocess,shutil
 system_apps_path = "system-apps"
 system_apps_repo = os.environ.get('SYSTEM_APPS_REPO') or "https://github.com/tavdog/tronbyt-apps.git"
 # check for existence of apps_path dir
-if not os.path.exists(system_apps_path):
+if os.path.exists(system_apps_path):
+    print("{} found, updating {}".format(system_apps_path,system_apps_repo))
+
+    result = subprocess.run(
+                        [
+                            "git",
+                            "pull",
+                            "--rebase",
+                            "true"
+                        ],
+                        cwd=system_apps_path
+                    )
+    if result.returncode != 0:
+        print("Error updating repo")
+    else:
+        print("Repo updated")
+else:
     print("{} not found, cloning {}".format(system_apps_path,system_apps_repo))
 
     result = subprocess.run(

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
       - "${PIXLET_SERVE_PORT1}:5100" # 5100 is used for pixlet serve interface during app configuration
       - "${PIXLET_SERVE_PORT2}:5101" # user 2
     volumes:
-      - .:/app
+      #- .:/app # for development
       - "/etc/localtime:/etc/localtime:ro" # used to sync docker with host time
     environment:
       - SERVER_HOSTNAME=${SERVER_HOSTNAME_OR_IP:?SERVER_HOSTNAME_OR_IP MUST BE SET IN .env FILE !!!!!!!!!!!!!!!!!.}
@@ -17,4 +17,3 @@ services:
       - PYTHONUNBUFFERED=1
       - SYSTEM_APPS_REPO=${SYSTEM_APPS_REPO}
       - PRODUCTION=${PRODUCTION}
-    command: /bin/sh -c "python3 clone_system_apps_repo.py && ./run"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
 flask
 gunicorn
+python-dotenv
+paho-mqtt
+python-pidfile
+esptool

--- a/run
+++ b/run
@@ -1,9 +1,11 @@
 #!/bin/bash
 
+python3 clone_system_apps_repo.py
+
 if [ "$PRODUCTION" = "1" ]; then
     # PRODUCTION
-    python3 -m gunicorn --config gunicorn.conf.py "tronbyt_server:create_app()"
+    exec python3 -m gunicorn --config gunicorn.conf.py "tronbyt_server:create_app()"
 else
     # DEVELOPMENT
-    FLASK_APP=tronbyt_server FLASK_DEBUG=1 flask run --host=0.0.0.0 --port=8000
+    FLASK_APP=tronbyt_server FLASK_DEBUG=1 exec flask run --host=0.0.0.0 --port=8000
 fi


### PR DESCRIPTION
- split image creation into two parts (builder and runtime) to avoid adding parts only needed at buildtime to the runtime image
- update the system apps clone at container startup
- use exec-form for CMD to ensure that tronbyt-server runs exec pid 1 and thus receives signals
- fix a few other hadolint warning
- copy the app code into the image to remove the need for cloning this repo (mount `/app` to overlay this during development)