### PR TITLE
Further reduce Docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,6 @@
 .venv
 .vscode
 Dockerfile
-docker-compose.yaml
+docker-compose*.yaml
 README.md
 tests

--- a/run
+++ b/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 python3 clone_system_apps_repo.py
 


### PR DESCRIPTION
Use Alpine base images and package the Python dependencies in a separate builder stage so that the runtime image doesn't have to contain the toolchain required to build the Python packages (gcc et.al.).

This reduces the final image size from 493 MB to 271 MB.