### PR TITLE
Add an example how to front tronbyt-server with Caddy for automatic HTTPS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 #SERVER_HOSTNAME_OR_IP="M1Pro.local" # UNCOMMENT AND SET
 SERVER_PORT=8000
+SERVER_PROTOCOL="http"
 PIXLET_SERVE_PORT1=5100
 PIXLET_SERVE_PORT2=5101 # add incremented port for each extra user past 2, or use host network mode in docker-compose file
 SYSTEM_APPS_REPO="https://github.com/tavdog/tronbyt-apps.git"

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 **/*.log
 .env
 env
+certs
 **/system-apps/**
 system-apps/**
 firmware/*.bin

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,9 @@
+https://localhost:8000 {
+	reverse_proxy http://web:8000
+}
+https://localhost:5000 {
+	reverse_proxy http://web:5000
+}
+https://localhost:5001 {
+	reverse_proxy http://web:5001
+}

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ That said, the recommended installation method uses Docker Compose with a config
 ### Notes
 
 - Ensure that the `SERVER_HOSTNAME_OR_IP` value is set in the `.env` file if you are not running the application locally. An IP address will also work here.
-- Do not try to run this server over HTTPS. It requires a pixlet serve subprocess to configure the apps and it only works over http and you can't jump from https to http in most browsers.
 
 ### Development
 
@@ -82,3 +81,11 @@ That said, the recommended installation method uses Docker Compose with a config
     ```sh
     docker compose -f docker-compose.dev.yaml up -d --build
     ```
+
+### HTTPS (TLS)
+
+If you'd like to serve tronbyt-server and pixlet over HTTPS, you can do so by fronting the services with a reverse proxy.
+
+The `docker-compose.https.yaml` file contains an example using [Caddy](https://caddyserver.com) as a lightweight reverse proxy which provides TLS termination. The default configuration uses [Local HTTPS](https://caddyserver.com/docs/automatic-https#local-https), for which Caddy generates its own certificate authority (CA) and uses it to sign certificates. The certificates are stored in the `certs` directory at `pki/authorities/local`.
+
+If you want to make tronbyt-server accessible using a public DNS name, adjust `Caddyfile` to match your domain name and use one of the supporte [ACME challenges](https://caddyserver.com/docs/automatic-https#acme-challenges) (HTTP, TLS-ALPN, or DNS).

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,7 @@
 services:
   web:
     image: ghcr.io/tavdog/tronbyt-server:latest
+    restart: unless-stopped
     ports:
       - "${SERVER_PORT}:8000" # Map port 8000 on the host to port 8000 in the container
       - "${PIXLET_SERVE_PORT1}:5100" # 5100 is used for pixlet serve interface during app configuration
@@ -11,6 +12,5 @@ services:
       - SERVER_HOSTNAME=${SERVER_HOSTNAME_OR_IP:?SERVER_HOSTNAME_OR_IP MUST BE SET IN .env FILE !!!!!!!!!!!!!!!!!.}
       - SERVER_PORT=${SERVER_PORT}
       - PIXLET_RENDER_PORT1=${PIXLET_SERVE_PORT1}
-      - PYTHONUNBUFFERED=1
       - SYSTEM_APPS_REPO=${SYSTEM_APPS_REPO}
       - PRODUCTION=${PRODUCTION}

--- a/tronbyt_server/__init__.py
+++ b/tronbyt_server/__init__.py
@@ -11,6 +11,7 @@ def create_app(test_config=None):
         SECRET_KEY='lksdj;as987q3908475ukjhfgklauy983475iuhdfkjghairutyh',
         MAX_CONTENT_LENGTH = 1000 * 1000, # 1mbyte upload size limit
         SERVER_HOSTNAME = os.environ['SERVER_HOSTNAME'] or 'localhost',
+        SERVER_PROTOCOL = os.environ['SERVER_PROTOCOL'] or 'http',
         MAIN_PORT = os.environ['SERVER_PORT'] or 8000,
         USERS_DIR = 'users',
     )
@@ -20,6 +21,7 @@ def create_app(test_config=None):
         SECRET_KEY='lksdj;as987q3908475ukjhfgklauy983475iuhdfkjghairutyh',
         MAX_CONTENT_LENGTH = 1000 * 1000, # 1mbyte upload size limit
         SERVER_HOSTNAME = os.environ['SERVER_HOSTANAME'] or 'localhost',
+        SERVER_PROTOCOL = os.environ['SERVER_PROTOCOL'] or 'http',
         USERS_DIR = 'tests/users',
     )
 

--- a/tronbyt_server/api.py
+++ b/tronbyt_server/api.py
@@ -236,7 +236,7 @@ def handle_delete(device_id,installation_id):
 #             device["name"] = name
 #             if not img_url:
 #                 sname = db.sanitize(name)
-#                 img_url = f"http://{current_app.config['SERVER_HOSTNAME']}:{current_app.config['MAIN_PORT']}/{device['id']}/next"
+#                 img_url = f"{current_app.config['SERVER_PROTOCOL']}://{current_app.config['SERVER_HOSTNAME']}:{current_app.config['MAIN_PORT']}/{device['id']}/next"
 #             device["img_url"] = img_url
 #             device["api_key"] = api_key
 #             device["notes"] = notes
@@ -304,7 +304,7 @@ def handle_delete(device_id,installation_id):
 #             device['timezone'] = int(request.form['timezone'])
 #             if len(img_url) < 1:
 #                 print("no img_url in device")
-#                 device["img_url"] = f"http://{current_app.config['SERVER_HOSTNAME']}:{current_app.config['MAIN_PORT']}/{device['id']}/next"
+#                 device["img_url"] = f"{current_app.config['SERVER_PROTOCOL']}://{current_app.config['SERVER_HOSTNAME']}:{current_app.config['MAIN_PORT']}/{device['id']}/next"
 #             else:
 #                 device["img_url"] = db.sanitize_url(img_url)
 #             device['night_mode_app'] = request.form['night_mode_app']
@@ -319,7 +319,7 @@ def handle_delete(device_id,installation_id):
 
 #             return redirect(url_for("manager.index"))
 #     device = g.user["devices"][id]
-#     server_root = f"http://{current_app.config['SERVER_HOSTNAME']}:{current_app.config['MAIN_PORT']}"
+#     server_root = f"{current_app.config['SERVER_PROTOCOL']}://{current_app.config['SERVER_HOSTNAME']}:{current_app.config['MAIN_PORT']}"
 #     return render_template("manager/update.html", device=device, server_root=server_root)
 
 
@@ -624,7 +624,7 @@ def handle_delete(device_id,installation_id):
 #     return render_template(
 #         "manager/firmware_form.html",
 #         device=g.user['devices'][id],
-#         server_root=f"http://{current_app.config['SERVER_HOSTNAME']}:{current_app.config['MAIN_PORT']}",
+#         server_root=f"{current_app.config['SERVER_PROTOCOL']}://{current_app.config['SERVER_HOSTNAME']}:{current_app.config['MAIN_PORT']}",
 #     )
 
 

--- a/tronbyt_server/manager.py
+++ b/tronbyt_server/manager.py
@@ -36,7 +36,7 @@ def index():
     if "devices" in g.user:
         devices = reversed(list(g.user["devices"].values()))
     server_root = (
-        f"http://{current_app.config['SERVER_HOSTNAME']}:{current_app.config['MAIN_PORT']}"
+        f"{current_app.config['SERVER_PROTOCOL']}://{current_app.config['SERVER_HOSTNAME']}:{current_app.config['MAIN_PORT']}"
     )
     return render_template("manager/index.html", devices=devices, server_root=server_root )
 
@@ -135,7 +135,7 @@ def create():
             device["name"] = name
             if not img_url:
                 sname = db.sanitize(name)
-                img_url = f"http://{current_app.config['SERVER_HOSTNAME']}:{current_app.config['MAIN_PORT']}/{device['id']}/next"
+                img_url = f"{current_app.config['SERVER_PROTOCOL']}://{current_app.config['SERVER_HOSTNAME']}:{current_app.config['MAIN_PORT']}/{device['id']}/next"
             device["img_url"] = img_url
             if not api_key or api_key == "":
                 api_key = "".join(
@@ -210,7 +210,7 @@ def update(device_id):
             device['timezone'] = int(request.form['timezone'])
             if len(img_url) < 1:
                 print("no img_url in device")
-                device["img_url"] = f"http://{current_app.config['SERVER_HOSTNAME']}:{current_app.config['MAIN_PORT']}/{device['id']}/next"
+                device["img_url"] = f"{current_app.config['SERVER_PROTOCOL']}://{current_app.config['SERVER_HOSTNAME']}:{current_app.config['MAIN_PORT']}/{device['id']}/next"
             else:
                 device["img_url"] = db.sanitize_url(img_url)
             device['night_mode_app'] = request.form['night_mode_app']
@@ -225,7 +225,7 @@ def update(device_id):
 
             return redirect(url_for("manager.index"))
     device = g.user["devices"][id]    
-    server_root = f"http://{current_app.config['SERVER_HOSTNAME']}:{current_app.config['MAIN_PORT']}"
+    server_root = f"{current_app.config['SERVER_PROTOCOL']}://{current_app.config['SERVER_HOSTNAME']}:{current_app.config['MAIN_PORT']}"
     return render_template("manager/update.html", device=device, server_root=server_root)
 
 
@@ -539,7 +539,7 @@ def generate_firmware(device_id):
     return render_template(
         "manager/firmware_form.html",
         device=g.user['devices'][device_id],
-        server_root=f"http://{current_app.config['SERVER_HOSTNAME']}:{current_app.config['MAIN_PORT']}",
+        server_root=f"{current_app.config['SERVER_PROTOCOL']}://{current_app.config['SERVER_HOSTNAME']}:{current_app.config['MAIN_PORT']}",
     )
 
 


### PR DESCRIPTION
This requires another change in the frontend which currently assumes all URLs to be HTTP (the places which use `SERVER_HOSTNAME`).