### PR TITLE
Proxy requests to `pixlet serve` through the Flask app

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,9 +1,3 @@
 https://localhost:8000 {
 	reverse_proxy http://web:8000
 }
-https://localhost:5100 {
-	reverse_proxy http://web:5100
-}
-https://localhost:5101 {
-	reverse_proxy http://web:5101
-}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /app
 COPY --from=pixlet-builder /bin/pixlet /pixlet/pixlet
 
 RUN apk --no-cache add esptool --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/ && \
-    apk --no-cache add python3 py3-flask py3-gunicorn py3-dotenv py3-requests \
+    apk --no-cache add python3 py3-flask py3-gunicorn py3-dotenv py3-requests py3-websocket-client \
                        libwebp libwebpmux libwebpdemux \
                        procps-ng git tzdata ca-certificates
 

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -4,9 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "${SERVER_PORT}:8000" # Map port 8000 on the host to port 8000 in the container
-      - "${PIXLET_SERVE_PORT1}:5100" # 5100 is used for pixlet serve interface during app configuration
-      - "${PIXLET_SERVE_PORT2}:5101" # user 2
+      - "${SERVER_PORT}:8000" # Map server port on the host to port 8000 in the container
     volumes:
       - .:/app # for development
       - "/etc/localtime:/etc/localtime:ro" # used to sync docker with host time

--- a/docker-compose.https.yaml
+++ b/docker-compose.https.yaml
@@ -32,8 +32,6 @@ services:
     ports:
       - "${SERVER_PORT}:8000" # Map port 8000 on the host to port 8000 in the container
       - "${SERVER_PORT}:8000/udp"
-      - "${PIXLET_SERVE_PORT1}:${PIXLET_SERVE_PORT1}" # 5100 is used for pixlet serve interface during app configuration
-      - "${PIXLET_SERVE_PORT2}:${PIXLET_SERVE_PORT2}" # user 2, add 1 incremented port each additional user you want or use host network_mode
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
       - ./certs:/data

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,9 +3,7 @@ services:
     image: ghcr.io/tavdog/tronbyt-server:latest
     restart: unless-stopped
     ports:
-      - "${SERVER_PORT}:8000" # Map port 8000 on the host to port 8000 in the container
-      - "${PIXLET_SERVE_PORT1}:5100" # 5100 is used for pixlet serve interface during app configuration
-      - "${PIXLET_SERVE_PORT2}:5101" # user 2, add 1 incremented port each additional user you want or use host network_mode
+      - "${SERVER_PORT}:8000" # Map server port on the host to port 8000 in the container
     volumes:
       - "/etc/localtime:/etc/localtime:ro" # used to sync docker with host time
       - users:/app/users

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ gunicorn
 python-dotenv
 esptool
 requests
+websocket-client

--- a/tronbyt_server/templates/manager/configapp.html
+++ b/tronbyt_server/templates/manager/configapp.html
@@ -13,6 +13,6 @@
 {% else %}
 <form action="{{ url_for('manager.index') }}" method="get"><input type="submit" value="Cancel"></form>
 {% endif %}
-<iframe src="{{protocol}}://{{domain_host}}:{{user_render_port}}/?{{url_params}}" width=100% height=2000
+<iframe src="{{ url_for('manager.pixlet_proxy') }}?{{url_params}}" width=100% height=2000
     title="Pixlet Serve"></iframe>
 {% endblock %}


### PR DESCRIPTION
This removes the need to expose the ports used by Pixlet.

Change the way the Flask app interact with Pixlet: instead of pointing the client to the pixlet instance's port, let the Flask app forward requests.

With this change, the app only exposes a single port which improves scalability (no need to adjust port configs after adding a user) allows TLS configuration with a given certificate only using gunicorn (example coming in a future PR).

The pixlet processes are still allocated static port numbers, which could be improved independently.