### PR TITLE
Use libpixlet to render applets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,28 @@
-# build pixlet
 FROM ghcr.io/tavdog/pixlet:latest AS pixlet-builder
 
 # build runtime image
-FROM alpine:edge AS runtime
+FROM debian:bookworm-slim AS runtime
 
 # 8000 for main app, 5100, 5101 for pixlet serve iframe
 EXPOSE 8000 5100 5101
 
 ENV PYTHONUNBUFFERED=1
+
 WORKDIR /app
 
 # copy pixlet binary and python dependencies
-COPY --from=pixlet-builder /bin/pixlet /pixlet/pixlet
+COPY --from=pixlet /bin/pixlet /pixlet/pixlet
+COPY --from=pixlet --chmod=755 /lib/libpixlet.so /usr/lib/libpixlet.so
 
-RUN apk --no-cache add esptool --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/ && \
-    apk --no-cache add python3 py3-flask py3-gunicorn py3-dotenv py3-requests py3-websocket-client \
-                       libwebp libwebpmux libwebpdemux \
-                       procps-ng git tzdata ca-certificates
+RUN echo deb http://deb.debian.org/debian bookworm-backports main > /etc/apt/sources.list.d/bookworm-backports.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        python3 python3-flask gunicorn python3-dotenv python3-requests python3-websocket python3-yaml \
+        libwebp7/bookworm-backports libwebpmux3/bookworm-backports libwebpdemux2/bookworm-backports \
+        procps git tzdata ca-certificates python3-pip && \
+    pip3 install esptool --break-system-packages && \
+    apt-get purge -y python3-pip && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY . /app
 

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -14,16 +14,5 @@ services:
       - PIXLET_RENDER_PORT1=${PIXLET_SERVE_PORT1}
       - PYTHONUNBUFFERED=1
       - SYSTEM_APPS_REPO=${SYSTEM_APPS_REPO}
-      - PRODUCTION=${PRODUCTION}
+      - PRODUCTION=0
       - PIXLET_API_URL=http://pixlet:8080
-    depends_on:
-      - pixlet
-    links:
-      - pixlet
-  pixlet:
-    image: ghcr.io/tavdog/pixlet:latest
-    command: ["api", "--host=0.0.0.0", "--port=8080"]
-    container_name: pixlet
-    volumes:
-      - .:/app # for development
-      - "/etc/localtime:/etc/localtime:ro" # used to sync docker with host time

--- a/docker-compose.https.yaml
+++ b/docker-compose.https.yaml
@@ -14,18 +14,6 @@ services:
       - SYSTEM_APPS_REPO=${SYSTEM_APPS_REPO}
       - PRODUCTION=${PRODUCTION}
       - PIXLET_API_URL=http://pixlet:8080
-    depends_on:
-      - pixlet
-    links:
-      - pixlet
-  pixlet:
-    image: ghcr.io/tavdog/pixlet:latest
-    command: ["api", "--host=0.0.0.0", "--port=8080"]
-    container_name: pixlet
-    restart: unless-stopped
-    volumes:
-      - .:/app # for development
-      - "/etc/localtime:/etc/localtime:ro" # used to sync docker with host time
   proxy:
     image: caddy:latest
     restart: unless-stopped

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,6 @@ services:
       - "/etc/localtime:/etc/localtime:ro" # used to sync docker with host time
       - users:/app/users
       - webp:/app/tronbyt_server/webp
-      - systemapps:/app/system-apps
     environment:
       - SERVER_HOSTNAME=${SERVER_HOSTNAME_OR_IP:?SERVER_HOSTNAME_OR_IP MUST BE SET IN .env FILE !!!!!!!!!!!!!!!!!.}
       - SERVER_PORT=${SERVER_PORT}
@@ -16,20 +15,6 @@ services:
       - SYSTEM_APPS_REPO=${SYSTEM_APPS_REPO}
       - PRODUCTION=${PRODUCTION}
       - PIXLET_API_URL=http://pixlet:8080
-    depends_on:
-      - pixlet
-    links:
-      - pixlet
-  pixlet:
-    image: ghcr.io/tavdog/pixlet:latest
-    command: ["api", "--host=0.0.0.0", "--port=8080"]
-    container_name: pixlet
-    restart: unless-stopped
-    volumes:
-      - users:/app/users
-      - systemapps:/app/system-apps # for development
-      - "/etc/localtime:/etc/localtime:ro" # used to sync docker with host time
 volumes:
   users:
   webp:
-  systemapps:

--- a/tronbyt_server/__init__.py
+++ b/tronbyt_server/__init__.py
@@ -1,9 +1,43 @@
+import ctypes
+import json
 import os
 
 from dotenv import load_dotenv
 from flask import Flask
 
 from tronbyt_server import db
+
+
+def render_app(
+    name,
+    config,
+    width,
+    height,
+    magnify,
+    maxDuration,
+    timeout,
+    render_gif,
+    silence_output,
+):
+    ret = pixlet_render_app(
+        name.encode("utf-8"),
+        json.dumps(config).encode("utf-8"),
+        width,
+        height,
+        magnify,
+        maxDuration,
+        timeout,
+        1 if render_gif else 0,
+        1 if silence_output else 0,
+    )
+    if ret.length >= 0:
+        data = ctypes.cast(
+            ret.data, ctypes.POINTER(ctypes.c_uint32 * ret.length)
+        ).contents
+        print("From Python: got data of length", ret.length)
+        buf = bytes(data)
+        free_bytes(ret.data)
+    return buf
 
 
 def create_app(test_config=None):
@@ -41,6 +75,41 @@ def create_app(test_config=None):
         os.makedirs(app.instance_path)
     except OSError:
         pass
+
+    if test_config is None:
+        print("Loading libpixlet")
+        try:
+            pixlet_library = ctypes.cdll.LoadLibrary("/usr/lib/libpixlet.so")
+        except OSError as e:
+            raise RuntimeError(f"Failed to load libpixlet: {e}")
+        init_cache = pixlet_library.init_cache
+        init_cache()
+
+        global pixlet_render_app
+        pixlet_render_app = pixlet_library.render_app
+        pixlet_render_app.argtypes = [
+            ctypes.c_char_p,
+            ctypes.c_char_p,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+        ]
+
+        class RenderAppReturn(ctypes.Structure):
+            _fields_ = [
+                ("data", ctypes.POINTER(ctypes.c_ubyte)),
+                ("length", ctypes.c_int),
+            ]
+
+        pixlet_render_app.restype = RenderAppReturn
+
+        global free_bytes
+        free_bytes = pixlet_library.free_bytes
+        free_bytes.argtypes = [ctypes.POINTER(ctypes.c_ubyte)]
 
     # Initialize the database within the application context
     with app.app_context():


### PR DESCRIPTION
This removes the need to run a pixlet container serving an API and enables pixlet's HTTP cache.

Fixes #74

Requires https://github.com/tavdog/pixlet/pull/9